### PR TITLE
(1.20.1-forge) Compatible with Obscure Tooltips & Issue fix & Simple config menu

### DIFF
--- a/1.20.1-forge/build.gradle
+++ b/1.20.1-forge/build.gradle
@@ -172,6 +172,10 @@ dependencies() {
     // https://www.curseforge.com/minecraft/mc-mods/legendary-tooltips/files/4662781
     compileOnly(fg.deobf("curse.maven:legendary-tooltips-532127:4662781"))
 
+    // Obscure Tooltips 2.2
+    // https://www.curseforge.com/minecraft/mc-mods/obscure-tooltips/files/4686579
+    compileOnly(fg.deobf("curse.maven:obscure-tooltips-715660:4686579"))
+
     implementation("cn.flowerinsnow.greatscrollabletooltips:common:[${version_common_module}]")
     jarJar("cn.flowerinsnow.greatscrollabletooltips:common:[${version_common_module}]")
 

--- a/1.20.1-forge/gradle.properties
+++ b/1.20.1-forge/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Great Scrollable Tooltips
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MPL-2.0
 # The mod version. See https://semver.org/
-mod_version=15.3.2+forge
+mod_version=15.4.0-beta.1+forge
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/listener/EventTriggerListener.java
+++ b/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/listener/EventTriggerListener.java
@@ -24,6 +24,7 @@ public class EventTriggerListener {
             if (this.oldScreen != null) {
                 MinecraftForge.EVENT_BUS.post(new ScreenCloseEvent(this.oldScreen));
             }
+            this.oldScreen = currentScreen;
         }
     }
 }

--- a/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/mixin/obscuretooltips/MixinTooltipRenderer.java
+++ b/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/mixin/obscuretooltips/MixinTooltipRenderer.java
@@ -1,0 +1,41 @@
+package cn.flowerinsnow.greatscrollabletooltips.mixin.obscuretooltips;
+
+import cn.flowerinsnow.greatscrollabletooltips.GreatScrollableTooltips;
+import cn.flowerinsnow.greatscrollabletooltips.common.config.GreatScrollableTooltipsConfig;
+import cn.flowerinsnow.greatscrollabletooltips.common.object.ScrollSession;
+import com.obscuria.tooltips.client.renderer.TooltipRenderer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(TooltipRenderer.class)
+@OnlyIn(Dist.CLIENT)
+public class MixinTooltipRenderer {
+    // Line 49: Vector2ic rawPos = positioner.positionTooltip(renderer.width(), renderer.height(), x, y, size.x, size.y);
+    @ModifyVariable(
+            method = "render",
+            at = @At(
+                    value = "STORE",
+                    opcode = Opcodes.ASTORE,
+                    ordinal = 0
+            ),
+            index = 9,
+            remap = false
+    )
+    private static Vector2ic render(Vector2ic value) {
+        GreatScrollableTooltips main = GreatScrollableTooltips.getInstance();
+        GreatScrollableTooltipsConfig config = main.getConfig();
+        ScrollSession<ItemStack> scrollSession = main.getScrollSession();
+
+        return new Vector2i(
+                value.x() + scrollSession.getHorizontal() * config.sensitivity,
+                value.y() + scrollSession.getVertical() * config.sensitivity
+        );
+    }
+}

--- a/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/mixinplugin/GreatScrollableTooltipsMixinPlugin.java
+++ b/1.20.1-forge/src/main/java/cn/flowerinsnow/greatscrollabletooltips/mixinplugin/GreatScrollableTooltipsMixinPlugin.java
@@ -21,8 +21,12 @@ public class GreatScrollableTooltipsMixinPlugin implements IMixinConfigPlugin {
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         // LegendaryTooltips
-        if ("online.flowerinsnow.greatscrollabletooltips.mixin.legendarytooltips.MixinLegendaryTooltips".equals(mixinClassName) || "online.flowerinsnow.greatscrollabletooltips.mixin.legendarytooltips.MixinItemModelComponent".equals(mixinClassName)) {
+        if ("cn.flowerinsnow.greatscrollabletooltips.mixin.legendarytooltips.MixinLegendaryTooltips".equals(mixinClassName)) {
             return FMLLoader.getLoadingModList().getModFileById("legendarytooltips") != null;
+        }
+        // Obscure Tooltips
+        if ("cn.flowerinsnow.greatscrollabletooltips.mixin.obscuretooltips.MixinTooltipRenderer".equals(mixinClassName)) {
+            return FMLLoader.getLoadingModList().getModFileById("obscure_tooltips") != null;
         }
         return true;
     }

--- a/1.20.1-forge/src/main/resources/great-scrollable-tooltips.mixins.json
+++ b/1.20.1-forge/src/main/resources/great-scrollable-tooltips.mixins.json
@@ -7,7 +7,8 @@
     "client": [
         "MixinHandledScreen",
         "MixinDrawContext",
-        "legendarytooltips.MixinLegendaryTooltips"
+        "legendarytooltips.MixinLegendaryTooltips",
+        "obscuretooltips.MixinTooltipRenderer"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
feat(1.20.1-forge): Compatible with Obscure Tooltips (#88)

fix(1.20.1-forge): fix the issue where scrolling won't reset when the screen closes and auto-reset was off

style(1.20.1-forge): make config menu simple